### PR TITLE
Add video filter panel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,7 +51,10 @@
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.12"
     },
-    "ghcr.io/kreemer/features/chrometesting:1": {}
+    "ghcr.io/kreemer/features/chrometesting:1": {},
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "17"
+    }
   }
   // optionally set remoteUser if needed
 }

--- a/docs/structurizr/video-file-processing.dsl
+++ b/docs/structurizr/video-file-processing.dsl
@@ -1,0 +1,85 @@
+workspace "Name" "Description"
+
+    !identifiers hierarchical
+
+    model {
+        u = person "User"
+        ss = softwareSystem "Bulk Video Reviewer" {
+            wa = container "Web Application" {
+                tags "Web Application"
+                c1 = component "comp"
+            }
+            addVideo = container "Add Video Use Case" "Handles the addition of new videos" {
+                tags "Use Case"
+            }
+            MetadataExtractor = container "Metadata Extractor" "Extracts metadata from videos" {
+                tags "Component"
+            }
+            VideoProcessingFactory = container "Video Processing Factory" "Creates video processing components" {
+                tags "Component"
+            }
+            DOMVideoProcessing = container "HTML DOM Video Processing" "Processes videos using HTML DOM methods" {
+                tags "Component"
+            }
+            FFMPEGVideoProcessing = container "FFMPEG Video Processing" "Processes videos using FFMPEG" {
+                tags "Component"
+            }
+            StorageAdapter = container "Storage Adapter" "Adapts storage operations" {
+                tags "Component"
+            }
+
+            db = container "LocalStorage Database" "Stores video metadata and related information" {
+                tags "Database"
+            }
+        }
+
+        u -> ss.wa "Uses"
+        ss.wa -> ss.addVideo "Submits video"
+        ss.addVideo -> ss.MetadataExtractor "Uses"
+        ss.MetadataExtractor -> ss.VideoProcessingFactory "Uses"
+        ss.VideoProcessingFactory -> ss.DOMVideoProcessing "Provides"
+        ss.VideoProcessingFactory -> ss.FFMPEGVideoProcessing "Provides"
+        
+        // Storage
+        ss.addVideo -> ss.StorageAdapter "Uses"
+        ss.StorageAdapter -> ss.db "Reads from and writes to"
+    }
+
+    views {
+        systemContext ss "Diagram1" {
+            include *
+            autolayout lr
+        }
+
+        container ss "Diagram2" {
+            include *
+            autolayout lr
+        }
+
+        styles {
+            element "Element" {
+                color #0773af
+                stroke #0773af
+                strokeWidth 7
+                shape roundedbox
+            }
+            element "Person" {
+                shape person
+            }
+            element "Boundary" {
+                strokeWidth 5
+            }
+            relationship "Relationship" {
+                thickness 4
+            }
+            element "Web Application" {
+                shape WebBrowser
+            }
+            element "Database" {
+                shape Cylinder
+            }
+            element "Use Case" {
+                shape Hexagon
+            }
+        }
+    }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,54 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import DiagnosticsPanel from '@presentation/components/utils/DiagnosticsPanel.vue'
+import FilterPanel from '@presentation/components/layout/FilterPanel.vue'
 import NavBar from '@presentation/views/NavBar.vue'
 import VideoGallery from '@presentation/views/VideoGallery.vue'
+import { useAppStateStore } from '@presentation/stores'
+
+const appStateStore = useAppStateStore()
+const { isFilterPanelOpen } = storeToRefs(appStateStore)
 </script>
 
 <template>
-  <NavBar />
+  <div class="app-shell" :class="{ 'panel-collapsed': !isFilterPanelOpen }">
+    <FilterPanel />
 
-  <VideoGallery />
+    <section class="content">
+      <NavBar />
 
-  <DiagnosticsPanel />
+      <VideoGallery />
+    </section>
+
+    <DiagnosticsPanel />
+  </div>
 </template>
+
+<style scoped>
+.app-shell {
+  --panel-size: 320px;
+  display: grid;
+  grid-template-columns: var(--panel-size) 1fr;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0d141e, #0a0f18 60%);
+}
+
+.app-shell.panel-collapsed {
+  --panel-size: 0px;
+}
+
+.content {
+  background: #0f1622;
+  min-height: 100vh;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .content {
+    order: 2;
+  }
+}
+</style>

--- a/src/infrastructure/video/services/videoDomUtils.ts
+++ b/src/infrastructure/video/services/videoDomUtils.ts
@@ -76,7 +76,11 @@ export const generateThumbnails = async (
   const thumbnails: string[] = []
   const durationIncrement = video.duration / count
 
-  for (let time = durationIncrement; time < video.duration; time += durationIncrement) {
+  for (
+    let time = durationIncrement;
+    time < video.duration;
+    time += durationIncrement
+  ) {
     await seekToTime(video, Math.floor(time))
     thumbnails.push(await captureThumbnail(video))
   }

--- a/src/presentation/components/inputs/FileInput.vue
+++ b/src/presentation/components/inputs/FileInput.vue
@@ -1,13 +1,13 @@
 <template>
-  <div>
-    <input
-      @change="handleInput"
-      type="file"
-      id="fileInput"
-      webkitdirectory
-      multiple
-    />
-  </div>
+  <label class="file-button" :for="inputId">Choose files</label>
+  <input
+    class="file-input"
+    @change="handleInput"
+    type="file"
+    :id="inputId"
+    webkitdirectory
+    multiple
+  />
   <div ref="videoWall"></div>
 </template>
 
@@ -15,6 +15,7 @@
 import { useVideoStore } from '@presentation/stores'
 
 const videoStore = useVideoStore()
+const inputId = 'fileInput'
 
 const handleInput = async (e: Event) => {
   if (!(e.target instanceof HTMLInputElement)) return
@@ -24,3 +25,31 @@ const handleInput = async (e: Event) => {
   }
 }
 </script>
+
+<style scoped>
+.file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.file-button {
+  display: inline-block;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f2f6fb;
+  cursor: pointer;
+  font: inherit;
+}
+
+.file-button:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+</style>

--- a/src/presentation/components/inputs/SelectDropdown.vue
+++ b/src/presentation/components/inputs/SelectDropdown.vue
@@ -1,0 +1,156 @@
+<template>
+  <div
+    class="custom-select"
+    :class="{ open: isOpen }"
+    @focusout="handleFocusOut"
+  >
+    <label v-if="label" :for="selectId" class="custom-select__label">
+      {{ label }}
+    </label>
+    <button
+      :id="selectId"
+      type="button"
+      class="custom-select__trigger"
+      @click="toggle"
+      @keydown.escape="close"
+    >
+      {{ activeLabel }}
+      <span class="chevron" aria-hidden="true">{{ isOpen ? '△' : '▽' }}</span>
+    </button>
+    <ul
+      v-if="isOpen"
+      class="custom-select__list"
+      role="listbox"
+      :aria-activedescendant="`option-${String(selected)}`"
+    >
+      <li
+        v-for="option in options"
+        :id="`option-${String(option.value)}`"
+        :key="String(option.value)"
+        class="custom-select__option"
+        :class="{ active: option.value === selected }"
+        role="option"
+        :aria-selected="option.value === selected"
+        @mousedown.prevent="select(option.value)"
+      >
+        {{ option.label }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+type SelectOption = {
+  label: string
+  value: string | number
+}
+
+const props = defineProps<{
+  options: SelectOption[]
+  selected: string | number
+  label?: string
+  selectId?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', value: string | number): void
+}>()
+
+const isOpen = ref(false)
+const selectId = props.selectId ?? 'column-select'
+
+const activeLabel = computed(
+  () =>
+    props.options.find((option) => option.value === props.selected)?.label ??
+    String(props.selected),
+)
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+
+function close() {
+  isOpen.value = false
+}
+
+function handleFocusOut(event: FocusEvent) {
+  const nextTarget = event.relatedTarget as HTMLElement | null
+  const root = event.currentTarget as HTMLElement
+
+  if (!root.contains(nextTarget)) {
+    close()
+  }
+}
+
+function select(value: string | number) {
+  emit('select', value)
+  close()
+}
+</script>
+
+<style scoped>
+.custom-select {
+  position: relative;
+}
+
+.custom-select__label {
+  display: inline-block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+  color: rgba(231, 237, 245, 0.9);
+}
+
+.custom-select__trigger {
+  width: 100%;
+  justify-content: space-between;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: left;
+  padding: 0.65rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f2f6fb;
+  cursor: pointer;
+  font: inherit;
+}
+
+.custom-select__trigger:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.custom-select__list {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 6px);
+  background: #0f1622;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+  padding: 0.35rem;
+  list-style: none;
+  margin: 0;
+  z-index: 2;
+}
+
+.custom-select__option {
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #f2f6fb;
+}
+
+.custom-select__option:hover,
+.custom-select__option.active {
+  background: rgba(110, 197, 255, 0.18);
+}
+
+.chevron {
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+</style>

--- a/src/presentation/components/layout/FilterPanel.vue
+++ b/src/presentation/components/layout/FilterPanel.vue
@@ -1,0 +1,285 @@
+<template>
+  <aside class="filter-panel" :class="{ closed: !isFilterPanelOpen }">
+    <header class="filter-panel__header">
+      <div>
+        <p class="filter-panel__eyebrow">Review controls</p>
+        <h2>Filters</h2>
+      </div>
+      <button class="ghost" @click="appStateStore.toggleFilterPanel()">
+        {{ isFilterPanelOpen ? 'Hide' : 'Show' }}
+      </button>
+    </header>
+
+    <section class="filter-panel__content">
+      <div class="control">
+        <label for="searchQuery">Search title</label>
+        <input
+          id="searchQuery"
+          v-model.trim="searchQuery"
+          type="text"
+          placeholder="e.g. onboarding walkthrough"
+        />
+      </div>
+
+      <div class="control control--inline">
+        <div>
+          <label for="minDuration">Min duration (minutes)</label>
+          <input
+            id="minDuration"
+            v-model="minDurationInput"
+            type="text"
+            inputmode="decimal"
+            placeholder="0"
+          />
+          <p v-if="minDurationValidation" class="hint error">
+            {{ minDurationValidation }}
+          </p>
+        </div>
+        <div>
+          <label for="maxDuration">Max duration (minutes)</label>
+          <input
+            id="maxDuration"
+            v-model="maxDurationInput"
+            type="text"
+            inputmode="decimal"
+            placeholder="no limit"
+          />
+          <p v-if="maxDurationValidation" class="hint error">
+            {{ maxDurationValidation }}
+          </p>
+        </div>
+      </div>
+
+      <p v-if="durationRangeWarning" class="hint warning">
+        {{ durationRangeWarning }}
+      </p>
+
+      <div class="control">
+        <SelectDropdown
+          label="Columns"
+          select-id="columnCount"
+          :options="columnOptions"
+          :selected="appStateStore.columnCount"
+          @select="(value) => (appStateStore.columnCount = Number(value))"
+        />
+        <p class="hint">Changes apply immediately to the gallery.</p>
+      </div>
+
+      <p class="hint subtle">
+        Pinned videos stay visible even when filters hide others.
+      </p>
+    </section>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import { useAppStateStore, useVideoStore } from '@presentation/stores'
+import SelectDropdown from '@/presentation/components/inputs/SelectDropdown.vue'
+
+const videoStore = useVideoStore()
+const appStateStore = useAppStateStore()
+
+const { minDuration, maxDuration, searchQuery } = storeToRefs(videoStore)
+const { isFilterPanelOpen } = storeToRefs(appStateStore)
+const columnOptions = [
+  { label: '2 columns', value: 2 },
+  { label: '3 columns', value: 3 },
+  { label: '4 columns', value: 4 },
+]
+
+const minDurationInput = ref(minDuration.value ? String(minDuration.value) : '')
+const maxDurationInput = ref(maxDuration.value ? String(maxDuration.value) : '')
+
+const minDurationValidation = ref('')
+const maxDurationValidation = ref('')
+
+const decimalPattern = /^\d*(\.\d+)?$/
+
+watch(minDurationInput, (value) => {
+  if (!value.trim()) {
+    minDurationValidation.value = ''
+    videoStore.setMinDuration(0)
+    return
+  }
+
+  if (!decimalPattern.test(value)) {
+    minDurationValidation.value = 'Use numbers only'
+    return
+  }
+
+  minDurationValidation.value = ''
+  videoStore.setMinDuration(parseFloat(value))
+})
+
+watch(maxDurationInput, (value) => {
+  if (!value.trim()) {
+    maxDurationValidation.value = ''
+    videoStore.setMaxDuration(0)
+    return
+  }
+
+  if (!decimalPattern.test(value)) {
+    maxDurationValidation.value = 'Use numbers only'
+    return
+  }
+
+  maxDurationValidation.value = ''
+  videoStore.setMaxDuration(parseFloat(value))
+})
+
+watch(minDuration, (value) => {
+  const numericValue = value ? String(value) : ''
+  if (numericValue !== minDurationInput.value) {
+    minDurationInput.value = numericValue
+  }
+})
+
+watch(maxDuration, (value) => {
+  const numericValue = value ? String(value) : ''
+  if (numericValue !== maxDurationInput.value) {
+    maxDurationInput.value = numericValue
+  }
+})
+
+const durationRangeWarning = computed(() => {
+  if (
+    maxDuration.value > 0 &&
+    minDuration.value > 0 &&
+    minDuration.value > maxDuration.value
+  ) {
+    return 'Max duration should be greater than min duration.'
+  }
+
+  return ''
+})
+</script>
+
+<style scoped>
+.filter-panel {
+  background: radial-gradient(circle at 20% 20%, #1f2a3b, #0e1623 60%);
+  color: #e7edf5;
+  min-height: 100vh;
+  padding: 1.5rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  transition:
+    width 0.3s ease,
+    padding 0.3s ease,
+    opacity 0.3s ease;
+  width: min(100%, var(--panel-size, 320px));
+  box-sizing: border-box;
+}
+
+.filter-panel.closed {
+  width: 0;
+  padding: 1.5rem 0 1.5rem 0;
+  opacity: 0.2;
+  overflow: hidden;
+}
+
+.filter-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.filter-panel__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(231, 237, 245, 0.6);
+  margin: 0;
+}
+
+h2 {
+  margin: 0.1rem 0 0;
+}
+
+.filter-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.control--inline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+  color: rgba(231, 237, 245, 0.9);
+}
+
+input,
+button {
+  font: inherit;
+}
+
+input {
+  padding: 0.6rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.08);
+  color: #f2f6fb;
+}
+
+input:focus {
+  outline: 2px solid #6ec5ff;
+  outline-offset: 2px;
+}
+
+.ghost {
+  padding: 0.45rem 0.8rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.04);
+  color: #f2f6fb;
+  cursor: pointer;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(231, 237, 245, 0.7);
+}
+
+.hint.error {
+  color: #ff8f8f;
+}
+
+.hint.warning {
+  color: #ffc164;
+}
+
+.hint.subtle {
+  color: rgba(231, 237, 245, 0.6);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .filter-panel {
+    min-height: auto;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .filter-panel.closed {
+    width: 100%;
+    height: 0;
+    padding: 0;
+  }
+}
+</style>

--- a/src/presentation/stores/appStateStore.ts
+++ b/src/presentation/stores/appStateStore.ts
@@ -10,6 +10,7 @@ export const useAppStateStore = defineStore('appState', () => {
 
   const isDiagnosticsPanelOpen = ref(false)
   const columnCount = ref(4) // Default to 4 columns
+  const isFilterPanelOpen = ref(true)
 
   function toggleDiagnosticsPanel(forceOpen?: boolean) {
     if (forceOpen !== undefined) {
@@ -19,9 +20,19 @@ export const useAppStateStore = defineStore('appState', () => {
     }
   }
 
+  function toggleFilterPanel(forceOpen?: boolean) {
+    if (forceOpen !== undefined) {
+      isFilterPanelOpen.value = forceOpen
+    } else {
+      isFilterPanelOpen.value = !isFilterPanelOpen.value
+    }
+  }
+
   return {
+    isFilterPanelOpen,
     isDiagnosticsPanelOpen,
     columnCount,
     toggleDiagnosticsPanel,
+    toggleFilterPanel,
   }
 })

--- a/src/presentation/stores/videosStore.ts
+++ b/src/presentation/stores/videosStore.ts
@@ -50,6 +50,8 @@ export const useVideoStore = defineStore('videos', () => {
 
   const videoMap = reactive(new Map<string, ParsedVideo>())
   const minDuration = ref(0)
+  const maxDuration = ref(0)
+  const searchQuery = ref('')
 
   const sortByVotes = computed<ParsedVideo[]>(() =>
     Array.from(videoMap.values()).sort(
@@ -64,11 +66,16 @@ export const useVideoStore = defineStore('videos', () => {
   const filteredVideos = computed<ParsedVideo[]>(() => {
     const minDurationFilter =
       minDuration.value > 0 ? minDuration.value * 60 : undefined
+    const maxDurationFilter =
+      maxDuration.value > 0 ? maxDuration.value * 60 : undefined
+    const normalizedSearchQuery = searchQuery.value.trim() || undefined
 
     return filterVideosUseCase.execute({
       videos: sortByPinned.value,
       options: {
         minDurationSeconds: minDurationFilter,
+        maxDurationSeconds: maxDurationFilter,
+        searchQuery: normalizedSearchQuery,
       },
     })
   })
@@ -141,8 +148,18 @@ export const useVideoStore = defineStore('videos', () => {
     minDuration.value = value >= 0 ? value : 0
   }
 
+  function setMaxDuration(value: number) {
+    maxDuration.value = value >= 0 ? value : 0
+  }
+
+  function setSearchQuery(value: string) {
+    searchQuery.value = value
+  }
+
   return {
     minDuration,
+    maxDuration,
+    searchQuery,
     filteredVideos,
     sortByPinned,
     sortByVotes,
@@ -151,6 +168,8 @@ export const useVideoStore = defineStore('videos', () => {
     removeVideo,
     removeAllUnpinned,
     setMinDuration,
+    setMaxDuration,
+    setSearchQuery,
     togglePinVideo,
     updateVideoThumbnails,
     updateVotes,

--- a/src/presentation/views/NavBar.vue
+++ b/src/presentation/views/NavBar.vue
@@ -1,72 +1,36 @@
 <template>
   <nav>
-    <h1>bulk-video-review</h1>
-    <FileInput />
+    <div class="nav-left">
+      <h1>bulk-video-review</h1>
+      <button class="ghost" @click="appStateStore.toggleFilterPanel()">
+        {{ isFilterPanelOpen ? 'Hide filters' : 'Show filters' }}
+      </button>
+    </div>
 
-    <div class="buttons">
-      <div class="button" @click="handleClearUnpinned">💣</div>
-    </div>
-    <div class="bulk-video-review">
-      <label for="durationFilter">Duration: </label>
-      <input
-        @keyup="handleDurationFilter"
-        type="text"
-        name="durationFilter"
-        id="durationFilter"
-        :placeholder="'Duration'"
-        :value="minDuration"
-      />
-      <span class="validationMessage">{{ durationValidationMessage }}</span>
-      <span @mouseup="appStateStore.toggleDiagnosticsPanel(true)">🧰</span>
-    </div>
-    <div class="column-selector">
-      <label for="columnCount">Columns: </label>
-      <select
-        id="columnCount"
-        v-model="appStateStore.columnCount"
-        @change="handleColumnChange"
-      >
-        <option value="2">2</option>
-        <option value="3">3</option>
-        <option value="4">4</option>
-      </select>
+    <div class="nav-actions">
+      <FileInput />
+
+      <button class="ghost" @click="handleClearUnpinned">Clear unpinned</button>
+
+      <button class="ghost" @click="appStateStore.toggleDiagnosticsPanel(true)">
+        Diagnostics
+      </button>
     </div>
   </nav>
 </template>
 
 <script setup lang="ts">
 import { useVideoStore, useAppStateStore } from '@presentation/stores'
-import { ref } from 'vue'
 import { storeToRefs } from 'pinia'
 
 import FileInput from '@presentation/components/inputs/FileInput.vue'
 
 const videoStore = useVideoStore()
 const appStateStore = useAppStateStore()
-
-const { minDuration } = storeToRefs(videoStore)
-
-const durationValidationMessage = ref('')
+const { isFilterPanelOpen } = storeToRefs(appStateStore)
 
 const handleClearUnpinned = () => {
   videoStore.removeAllUnpinned()
-}
-
-function handleDurationFilter(e: Event) {
-  const inputElement = e.target as HTMLInputElement
-  const regex = /^\d+$/
-
-  regex.test(inputElement.value) || !inputElement.value
-    ? (durationValidationMessage.value = '')
-    : (durationValidationMessage.value = 'Only numbers')
-
-  const value = parseFloat(inputElement.value) || 0
-  videoStore.setMinDuration(value)
-}
-
-function handleColumnChange(e: Event) {
-  const selectElement = e.target as HTMLSelectElement
-  appStateStore.columnCount = parseInt(selectElement.value)
 }
 </script>
 
@@ -74,16 +38,17 @@ function handleColumnChange(e: Event) {
 nav {
   position: sticky;
   top: 0;
-  padding: 0.5em 0;
-  background-color: brown;
+  padding: 0.65em 1.5em;
+  background-color: #0c121b;
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 nav > h1 {
-  color: aliceblue;
+  color: #f2f6fb;
   padding: 0;
   margin: 0;
 }
@@ -94,56 +59,24 @@ main {
   flex-direction: column;
 }
 
-header input {
-  height: 2em;
-}
-
-.bulk-video-review {
-  padding: 0 1em;
-  color: aliceblue;
-}
-
-.bulk-video-review > input {
-  margin: 0 10px;
-}
-
-.bulk-video-review > span {
-  padding-left: 1em;
-}
-
-.validationMessage {
-  color: white;
-}
-
-.errorMessage {
-  background-color: white;
-  left: 30%;
-  color: red;
-  font-weight: bold;
-  padding: 0.5em 1em;
-  border-radius: 10px;
-  position: absolute;
-}
-
-.button {
-  padding: 0.25em 0.5em;
-  background-color: azure;
-  border: 1px solid black;
-  border-radius: 5px;
-  margin: 0 0 0 0.5em;
-  cursor: pointer;
-}
-
-.buttons {
+.nav-actions {
   display: flex;
-  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.column-selector {
-  color: aliceblue;
+.nav-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.column-selector select {
-  margin-left: 0.5em;
+.ghost {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f2f6fb;
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
- Moved filtering controls into a dedicated side panel with refined styling and toggle behavior.
- Added searchable titles plus min/max duration filters with inline validation.
- Introduced reusable dropdown inputs (file picker styled, custom select) and wired columns to a simple
  SelectDropdown using { label, value } options.
- Added a filter panel toggle and kept pinned videos visible regardless of filters; column count now updates
  via the panel dropdown.